### PR TITLE
Allow accounts list to be read

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # yktotp-jsonapi
 
-**❗This is still work in progress and only tested on a Linux operating system in conjunction with
+**❗This is still work in progress and only tested on Windows 10 and a Linux operating system in conjunction with
 Google Chrome Beta.❗**
 
 Get TOTP codes from a YubiKey. Intended to be called from the
@@ -8,6 +8,11 @@ Get TOTP codes from a YubiKey. Intended to be called from the
 
 ## Installation
 
+### Windows
+- Clone the repository and ensure you have `cargo` (Rust) available on your path
+- In a powershell with administrator rights, run `.\install.ps1`.
+
+### Linux
 - Run `cargo build --release`. This builds the executable `target/release/yktotp-jsonapi`.
 - Edit the [Native Messaging host manifest](manifest/de.nilsalex.yktotp.json) and update the `path` field
   to the path of the `yktotp-jsonapi` executable.

--- a/src/api.rs
+++ b/src/api.rs
@@ -125,6 +125,7 @@ mod tests {
 
     #[test_case(b"{\"type\":\"Code\",\"account\":\"rust-lang.org\"}", Request::Code { account: String::from("rust-lang.org")}; "works with proper json")]
     #[test_case(b"{\"type\":\"Code\",\"account\":\"rust-lang.org\",\"extra\":\"extra_field\"}", Request::Code { account: String::from("rust-lang.org")}; "ignores additional fields")]
+    #[test_case(b"{\"type\":\"AccountList\"}", Request::AccountList; "works with account list request")]
     fn deserialize_request_succeeds(bytes: &[u8], request: Request) {
         let deserialized = deserialize_request(bytes).unwrap();
         assert_eq!(
@@ -148,6 +149,7 @@ mod tests {
     }
 
     #[test_case(& Response::Code{account: String::from("rust-lang.org"), code: String::from("123456")}, b"\x2B\x00\x00\x00{\"account\":\"rust-lang.org\",\"code\":\"123456\"}"; "succeeds for response with code")]
+    #[test_case(& Response::AccountList{accounts: vec![String::from("rust-lang.org"), String::from("zombo.com")]}, b"\x2A\x00\x00\x00{\"accounts\":[\"rust-lang.org\",\"zombo.com\"]}"; "succeeds for response with account list")]
     #[test_case(& Response::Error{account: String::from("rust-lang.org"), error: String::from("some error")}, b"\x30\x00\x00\x00{\"account\":\"rust-lang.org\",\"error\":\"some error\"}"; "succeeds for response with error")]
     fn serialize_response_succeeds(response: &Response, bytes: &[u8]) {
         let serialized = serialize_response(response).unwrap();

--- a/src/api.rs
+++ b/src/api.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "type")]
 pub enum Request {
     AccountList,
-    Code { account: String},
+    Code { account: String },
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -31,10 +31,10 @@ pub enum Error {
     Oath(oath::Error),
 }
 
-pub fn handle_request(request: &Request) -> Result<Response, Error> {
+pub fn handle_request(request: &Request) -> Response {
     match request {
-        Request::Code {account} => Ok(read_otp(&account)),
-        Request::AccountList => Ok(read_accounts_list()),
+        Request::Code { account } => read_otp(&account),
+        Request::AccountList => read_accounts_list(),
     }
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -20,7 +20,7 @@ pub enum Request {
 pub enum Response {
     Code { account: String, code: String },
     AccountList { accounts: Vec<String> },
-    Error { account: String, error: String },
+    Error { error: String },
 }
 
 #[derive(Debug)]
@@ -48,7 +48,6 @@ fn read_accounts_list() -> Response {
             accounts: account_vec,
         },
         Err(e) => Response::Error {
-            account: "".to_owned(),
             error: format!("{:?}", e),
         },
     }
@@ -66,7 +65,6 @@ fn read_otp(search_term: &str) -> Response {
             code: format!("{:06}", code),
         },
         Err(e) => Response::Error {
-            account: search_term.to_owned(),
             error: format!("{:?}", e),
         },
     }
@@ -149,8 +147,8 @@ mod tests {
     }
 
     #[test_case(& Response::Code{account: String::from("rust-lang.org"), code: String::from("123456")}, b"\x2B\x00\x00\x00{\"account\":\"rust-lang.org\",\"code\":\"123456\"}"; "succeeds for response with code")]
-    #[test_case(& Response::AccountList{accounts: vec![String::from("rust-lang.org"), String::from("zombo.com")]}, b"\x2A\x00\x00\x00{\"accounts\":[\"rust-lang.org\",\"zombo.com\"]}"; "succeeds for response with account list")]
-    #[test_case(& Response::Error{account: String::from("rust-lang.org"), error: String::from("some error")}, b"\x30\x00\x00\x00{\"account\":\"rust-lang.org\",\"error\":\"some error\"}"; "succeeds for response with error")]
+    #[test_case(& Response::AccountList{accounts: vec ! [String::from("rust-lang.org"), String::from("zombo.com")]}, b"\x2A\x00\x00\x00{\"accounts\":[\"rust-lang.org\",\"zombo.com\"]}"; "succeeds for response with account list")]
+    #[test_case(& Response::Error{error: String::from("some error")}, b"\x16\x00\x00\x00{\"error\":\"some error\"}"; "succeeds for response with error")]
     fn serialize_response_succeeds(response: &Response, bytes: &[u8]) {
         let serialized = serialize_response(response).unwrap();
         assert_eq!(


### PR DESCRIPTION
The API is quite rough, because I'm not sure how to allow optional fields in the request structs.
So the "account" field is required, even though it means nothing for "getList" requests.

Improvements to my rust code are very welcome - this is pretty much my first commit in Rust :)